### PR TITLE
feat: 変数宣言の解釈機を追加

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -13,6 +13,11 @@ class NameNotDefinedException(PatternException):
         return f"[{self.arg}]は変数として定義されていません。"
 
 
+class DeclareException(PatternException):
+    def __str__(self):
+        return f"宣言の記述が不正です：{self.arg}"
+
+
 class InvalidFormulaException(PatternException):
     def __str__(self):
         return f"式が不正です：{self.arg}"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -240,3 +240,19 @@ def test_interpret_var_declare():
     assert interpreter.name_type_map["b"] == "整数型"
     assert interpreter.name_type_map["c"] == "整数型"
     remain == ""
+
+
+def test_process_var_assigns_and_use():
+    interpreter = Interpreter()
+    actual_list, remain = interpreter.process_var_assigns("a←1+2+3, b, c←5.4")
+
+    assert actual_list == ["a", "b", "c"]
+    assert interpreter.name_val_map["a"] == 6
+    assert interpreter.name_val_map["b"] is None
+    assert interpreter.name_val_map["c"] == 5.4
+    assert remain == ""
+
+    interpreter.process_var_assigns("b←a + c * 2")
+    assert interpreter.name_val_map["b"] == 16.8
+    actual_val, remain = interpreter.interpret_arithmetic_formula("a+b+c")
+    assert actual_val == 16.8 + 5.4 + 6


### PR DESCRIPTION
# 対応内容

変数宣言と代入の記述に対する解釈器を追加しました。
宣言した変数は式に対しても利用でき、変数に存在する値で計算が行われます。

# テスト項目

- [x] 変数が宣言できること
- [x] 宣言した変数に代入ができること
- [x] 宣言、代入した変数が式の中で利用できること