### PR TITLE
feat: for ブロックをLTSに変換する解釈器を追加

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -57,6 +57,19 @@ class InvalidDoWhileBlockException(PatternException):
         super().__init__(arg, line_num)
         self.message = "do while文が正しく終了しませんでした。"
 
+
+class InvalidForBlockException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = "for文が正しく終了しませんでした。"
+
+
+class InvalidForSentenceException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = "for文の繰り返しの定義正しくありません。"
+
+
 class InvalidIndentException(PatternException):
     def __init__(self, arg="", line_num=None):
         super().__init__(arg, line_num)


### PR DESCRIPTION
# 対応内容

for ブロックの解釈器を追加しました。この解釈器はforブロックの内容をLTSに変換します。LTSは各行の処理内容をラベルとして作成しています。

Close #9

# テスト項目
- [x] for句が解釈できること
- [x] forブロックの入れ子構造が解釈できること
