### PR TITLE
feat: return句の解釈器を追加

### DIFF
--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -637,6 +637,7 @@ class Interpreter:
         self,
         lines: List[str],
         line_pointa: int,
+        return_tuples: List[Tuple[str, str]],
         in_label: str | None = None,
         indent: str = "",
         start_state: str | None = None,

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -390,6 +390,8 @@ class Interpreter:
         if not res:
             return None
         _, remain = res
+        if remain.strip() == "":
+            return ""
         return self.interpret_arithmetic_formula(
             remain, dry_run=dry_run, line_num=line_num
         )

--- a/src/lts/lts.py
+++ b/src/lts/lts.py
@@ -37,6 +37,14 @@ class LabeledTransitionSystem:
         self.transitions[source][label] = target
         self.backwards[target].add((label, source))
 
+    def clear_transition(self, source: str):
+        if source not in self.transitions:
+            raise exception.DoesNotExistException(source)
+        for label in self.transitions[source]:
+            target = self.transitions[source][label]
+            self.backwards[target].remove((label, source))
+        self.transitions[source] = {}
+
     def get_transition_state(self, source: str, label: str):
         if source not in self.transitions:
             raise exception.DoesNotExistException(source)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -244,6 +244,14 @@ def test_interpret_var_declare():
     remain == ""
 
 
+def test_interpret_var_assign():
+    interpreter = Interpreter()
+    remain = interpreter.interpret_var_declare("整数型：a←1")
+    remain = interpreter.interpret_var_assign("a←a+2+3")
+    assert interpreter.name_val_map["a"] == 6
+    assert remain == ""
+
+
 def test_process_var_assigns_and_use():
     interpreter = Interpreter()
     actual_list, remain = interpreter.process_var_assigns("a←1+2+3, b, c←5.4")
@@ -275,7 +283,7 @@ def test_interpret_if_block():
         "endif",
         "c=a+b",
     ]
-    remains = interpreter.interpret_if_block(lines)
+    remains = interpreter.interpret_if_block(lines, [])
     assert len(interpreter.lts.transitions) == 11
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
     assert interpreter.lts.get_transition_state("S1", "整数型:a←1+2") == "S2"
@@ -302,7 +310,7 @@ def test_interpret_if_block_without_any_else():
         "endif",
         "c=a+b",
     ]
-    remains = interpreter.interpret_if_block(lines)
+    remains = interpreter.interpret_if_block(lines, [])
     assert len(interpreter.lts.transitions) == 6
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
     assert interpreter.lts.get_transition_state("S1", "整数型:a←1+2") == "S2"
@@ -326,7 +334,7 @@ def test_interpret_if_block_without_elseif():
         "endif",
         "c=a+b",
     ]
-    remains = interpreter.interpret_if_block(lines)
+    remains = interpreter.interpret_if_block(lines, [])
     assert len(interpreter.lts.transitions) == 8
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
     assert interpreter.lts.get_transition_state("S1", "整数型:a←1+2") == "S2"
@@ -352,7 +360,7 @@ def test_interpret_if_block_without_else():
         "endif",
         "c=a+b",
     ]
-    remains = interpreter.interpret_if_block(lines)
+    remains = interpreter.interpret_if_block(lines, [])
     assert len(interpreter.lts.transitions) == 9
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
     assert interpreter.lts.get_transition_state("S1", "整数型:a←1+2") == "S2"
@@ -378,7 +386,7 @@ def test_interpret_if_block_invalid_if_end():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidIfBlockException) as e:
-        interpreter.interpret_if_block(lines)
+        interpreter.interpret_if_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "4行目:if文が正しく終了しませんでした。"
@@ -394,7 +402,7 @@ def test_interpret_if_block_invalid_indent():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidIndentException) as e:
-        interpreter.interpret_if_block(lines)
+        interpreter.interpret_if_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "3行目:インデントに誤りがあります。"
@@ -414,7 +422,7 @@ def test_interpret_if_block_invalid_indent_elseif():
     ]
 
     with pytest.raises(exception.InvalidIndentException) as e:
-        interpreter.interpret_if_block(lines)
+        interpreter.interpret_if_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "6行目:インデントに誤りがあります。"
@@ -433,7 +441,7 @@ def test_interpret_if_block_invalid_indent_else():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidIndentException) as e:
-        interpreter.interpret_if_block(lines)
+        interpreter.interpret_if_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "6行目:インデントに誤りがあります。"
@@ -455,7 +463,7 @@ def test_interpret_nested_if_block():
         "endif",
         "c=a+b",
     ]
-    remains = interpreter.interpret_if_block(lines)
+    remains = interpreter.interpret_if_block(lines, [])
     assert len(interpreter.lts.transitions) == 13
     print(interpreter.lts)
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
@@ -485,7 +493,7 @@ def test_interpret_while_block():
         "endwhile",
         "c=a+b",
     ]
-    remains = interpreter.interpret_while_block(lines)
+    remains = interpreter.interpret_while_block(lines, [])
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 5
     assert interpreter.lts.get_transition_state("S0", "(a>4)") == "S1"
@@ -514,7 +522,7 @@ def test_interpret_nested_while_block():
         "endwhile",
         "c=a+b",
     ]
-    remains = interpreter.interpret_while_block(lines)
+    remains = interpreter.interpret_while_block(lines, [])
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 14
     print(interpreter.lts)
@@ -548,7 +556,7 @@ def test_interpret_while_block_invalid_end():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidWhileBlockException) as e:
-        interpreter.interpret_while_block(lines)
+        interpreter.interpret_while_block(lines, [])
         print(interpreter.lts)
 
     # エラーメッセージを検証
@@ -565,7 +573,7 @@ def test_interpret_while_block_invalid_indent():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidIndentException) as e:
-        interpreter.interpret_while_block(lines)
+        interpreter.interpret_while_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "3行目:インデントに誤りがあります。"
@@ -580,7 +588,7 @@ def test_interpret_do_while_block():
         "while(a>4)",
         "c=a+b",
     ]
-    remains = interpreter.interpret_do_while_block(lines)
+    remains = interpreter.interpret_do_while_block(lines, [])
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 5
     assert interpreter.lts.get_transition_state("S0", "do") == "S1"
@@ -609,7 +617,7 @@ def test_interpret_nested_do_while_block():
         "while(1>3)",
         "c=a+b",
     ]
-    remains = interpreter.interpret_do_while_block(lines)
+    remains = interpreter.interpret_do_while_block(lines, [])
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 14
     print(interpreter.lts)
@@ -643,7 +651,7 @@ def test_interpret_do_while_block_invalid_end():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidDoWhileBlockException) as e:
-        interpreter.interpret_do_while_block(lines)
+        interpreter.interpret_do_while_block(lines, [])
         print(interpreter.lts)
 
     # エラーメッセージを検証
@@ -660,7 +668,7 @@ def test_interpret_do_while_block_invalid_indent():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidIndentException) as e:
-        interpreter.interpret_do_while_block(lines)
+        interpreter.interpret_do_while_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "3行目:インデントに誤りがあります。"
@@ -675,7 +683,7 @@ def test_interpret_for_block():
         "endfor",
         "c=a+b",
     ]
-    remains = interpreter.interpret_for_block(lines)
+    remains = interpreter.interpret_for_block(lines, [])
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 5
     assert interpreter.lts.get_transition_state("S0", "(aを1から4まで繰り返す)") == "S1"
@@ -704,7 +712,7 @@ def test_interpret_nested_for_block():
         "endfor",
         "c=a+b",
     ]
-    remains = interpreter.interpret_for_block(lines)
+    remains = interpreter.interpret_for_block(lines, [])
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 14
     print(interpreter.lts)
@@ -738,7 +746,7 @@ def test_interpret_for_block_invalid_end():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidForBlockException) as e:
-        interpreter.interpret_for_block(lines)
+        interpreter.interpret_for_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "4行目:for文が正しく終了しませんでした。"
@@ -754,7 +762,7 @@ def test_interpret_for_block_invalid_indent():
         "c=a+b",
     ]
     with pytest.raises(exception.InvalidIndentException) as e:
-        interpreter.interpret_for_block(lines)
+        interpreter.interpret_for_block(lines, [])
 
     # エラーメッセージを検証
     assert str(e.value) == "3行目:インデントに誤りがあります。"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -459,11 +459,13 @@ def test_interpret_nested_if_block():
         "    else",
         "        整数型:a←7",
         "        整数型:b←8+2",
+        "        return",
         "    endif",
         "endif",
         "c=a+b",
     ]
-    remains = interpreter.interpret_if_block(lines, [])
+    actual_returns = []
+    remains = interpreter.interpret_if_block(lines, actual_returns)
     assert len(interpreter.lts.transitions) == 13
     print(interpreter.lts)
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
@@ -480,8 +482,8 @@ def test_interpret_nested_if_block():
     assert interpreter.lts.get_transition_state("S10", "endif") == "S12"
     assert interpreter.lts.get_transition_state("S0", "else") == "S11"
     assert interpreter.lts.get_transition_state("S11", "endif") == "S12"
-
-    assert remains == 11
+    assert ("S9", "return") in actual_returns
+    assert remains == 12
 
 
 def test_interpret_while_block():
@@ -517,13 +519,15 @@ def test_interpret_nested_while_block():
         "        if(a>4)",
         "            整数型:a←6+1",
         "            整数型:b←7+2",
+        "        else",
+        "            return",
         "        endif",
         "    endwhile",
         "endwhile",
         "c=a+b",
     ]
-    remains = interpreter.interpret_while_block(lines, [])
-    print(interpreter.lts)
+    actual_returns = []
+    remains = interpreter.interpret_while_block(lines, actual_returns)
     assert len(interpreter.lts.transitions) == 14
     print(interpreter.lts)
     assert interpreter.lts.get_transition_state("S0", "(1>3)") == "S1"
@@ -542,8 +546,9 @@ def test_interpret_nested_while_block():
     assert interpreter.lts.get_transition_state("S10", "endif") == "S11"
     assert interpreter.lts.get_transition_state("S11", "") == "S3"
     assert interpreter.lts.get_transition_state("S12", "") == "S0"
+    assert ("S10", "return") in actual_returns
 
-    assert remains == 12
+    assert remains == 14
 
 
 def test_interpret_while_block_invalid_end():
@@ -612,13 +617,15 @@ def test_interpret_nested_do_while_block():
         "        if(a>4)",
         "            整数型:a←6+1",
         "            整数型:b←7+2",
+        "        else",
+        "            return",
         "        endif",
         "    endwhile",
         "while(1>3)",
         "c=a+b",
     ]
-    remains = interpreter.interpret_do_while_block(lines, [])
-    print(interpreter.lts)
+    actual_returns = []
+    remains = interpreter.interpret_do_while_block(lines, actual_returns)
     assert len(interpreter.lts.transitions) == 14
     print(interpreter.lts)
     assert interpreter.lts.get_transition_state("S0", "do") == "S1"
@@ -637,8 +644,8 @@ def test_interpret_nested_do_while_block():
     assert interpreter.lts.get_transition_state("S11", "") == "S3"
     assert interpreter.lts.get_transition_state("S12", "(1>3)") == "S0"
     assert interpreter.lts.get_transition_state("S12", "else") == "S13"
-
-    assert remains == 12
+    assert ("S10", "return") in actual_returns
+    assert remains == 14
 
 
 def test_interpret_do_while_block_invalid_end():
@@ -707,15 +714,17 @@ def test_interpret_nested_for_block():
         "        if(a>4)",
         "            整数型:a←6+1",
         "            整数型:b←7+2",
+        "        else",
+        "            return",
         "        endif",
         "    endwhile",
         "endfor",
         "c=a+b",
     ]
-    remains = interpreter.interpret_for_block(lines, [])
+    actual_returns = []
+    remains = interpreter.interpret_for_block(lines, actual_returns)
     print(interpreter.lts)
     assert len(interpreter.lts.transitions) == 14
-    print(interpreter.lts)
     assert interpreter.lts.get_transition_state("S0", "(aを1から4まで繰り返す)") == "S1"
     assert interpreter.lts.get_transition_state("S0", "endfor") == "S13"
     assert interpreter.lts.get_transition_state("S1", "整数型:a←1+2") == "S2"
@@ -732,8 +741,8 @@ def test_interpret_nested_for_block():
     assert interpreter.lts.get_transition_state("S10", "endif") == "S11"
     assert interpreter.lts.get_transition_state("S11", "") == "S3"
     assert interpreter.lts.get_transition_state("S12", "") == "S0"
-
-    assert remains == 12
+    assert ("S10", "return") in actual_returns
+    assert remains == 14
 
 
 def test_interpret_for_block_invalid_end():
@@ -780,10 +789,11 @@ def test_interpret_func_block():
     print(interpreter.lts)
     assert "test_func" in interpreter.func_lts_map
     test_func_lts = interpreter.func_lts_map["test_func"]
-    assert len(test_func_lts.transitions) == 3
+    assert len(test_func_lts.transitions) == 4
     assert len(interpreter.lts.transitions) == 1
     assert test_func_lts.get_transition_state("S0", "整数型:a←1+2") == "S1"
     assert test_func_lts.get_transition_state("S1", "整数型:b←2+3") == "S2"
+    assert test_func_lts.get_transition_state("S2", "return") == "S3"
 
     assert remains == 3
 
@@ -800,6 +810,8 @@ def test_interpret_nested_func_block():
         "        if(a>4)",
         "            整数型:a←6+1",
         "            整数型:b←7+2",
+        "        else",
+        "            return",
         "        endif",
         "    endwhile",
         "c=a+b",
@@ -808,13 +820,14 @@ def test_interpret_nested_func_block():
     print(interpreter.func_lts_map["test_func"])
     assert "test_func" in interpreter.func_lts_map
     test_func_lts = interpreter.func_lts_map["test_func"]
-    assert len(test_func_lts.transitions) == 12
+    assert len(test_func_lts.transitions) == 13
     assert len(interpreter.lts.transitions) == 1
     print(interpreter.lts)
     assert test_func_lts.get_transition_state("S0", "整数型:a←1+2") == "S1"
     assert test_func_lts.get_transition_state("S1", "整数型:b←2+3") == "S2"
     assert test_func_lts.get_transition_state("S2", "(4<2)") == "S3"
     assert test_func_lts.get_transition_state("S2", "endwhile") == "S11"
+    assert test_func_lts.get_transition_state("S11", "return") == "S12"
     assert test_func_lts.get_transition_state("S3", "整数型:a←4") == "S4"
     assert test_func_lts.get_transition_state("S4", "整数型:b←5+1") == "S5"
     assert test_func_lts.get_transition_state("S5", "(a>4)") == "S6"
@@ -822,10 +835,10 @@ def test_interpret_nested_func_block():
     assert test_func_lts.get_transition_state("S7", "整数型:b←7+2") == "S8"
     assert test_func_lts.get_transition_state("S8", "endif") == "S10"
     assert test_func_lts.get_transition_state("S5", "else") == "S9"
-    assert test_func_lts.get_transition_state("S9", "endif") == "S10"
+    assert test_func_lts.get_transition_state("S9", "return") == "S12"
     assert test_func_lts.get_transition_state("S10", "") == "S2"
 
-    assert remains == 11
+    assert remains == 13
 
 
 def test_interpret_func_block_invalid_indent():


### PR DESCRIPTION
# 対応内容

return句の解釈器を追加しました。各ブロックでreturn句が存在した場合は遷移元の状態と一緒に保存しておき、関数またはメインのプロセスの解釈の最後にまとめて最終状態へとつなぎ直すように修正しました。
また、return句が明示的に存在しない場合もreturnの遷移が追加されるようにしました。

Close #20

# テスト項目
- [x] return句が解釈できること
- [x] 各ブロックで存在するreturn句が最終状態に遷移すること
- [x] return句が存在しない場合もLTSにreturnによる遷移が追加されること