### PR TITLE
feat: 関数の引数の解釈器を追加

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -24,6 +24,17 @@ class FuncNameException(PatternException):
         self.message = f"[{self.arg}]は関数に利用できません。"
 
 
+class InvalidFuncDeclareException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = f"{self.args}の関数定義が正しくありません。"
+
+
+class FuncArgNotFoundException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = f"[{self.arg}]に関数の引数が見つかりません。"
+
 
 class NamePatternException(PatternException):
     def __init__(self, arg="", line_num=None):


### PR DESCRIPTION
# 対応内容
関数の引数を解釈できるようにしました。解釈された関数は現状では他の変数と同様に管理されます。
関数やブロック単位での変数のスコープ管理は現状は行っていません。


Close #21

# テスト項目
- [x] 関数の引数を解釈できること
