### PR TITLE
feat: 配列の解釈器を追加

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -72,6 +72,17 @@ class InvalidSquareBracketException(PatternException):
         self.message = '"["に対応する"]"が存在しません。'
 
 
+class InvalidArrayException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = f"{self.arg}は配列ではありません。"
+
+
+class InvalidArrayIndexException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = f"{self.arg}の配列外にアクセスしています。"
+
 
 class InvalidIfBlockException(PatternException):
     def __init__(self, arg="", line_num=None):

--- a/src/exception.py
+++ b/src/exception.py
@@ -27,7 +27,7 @@ class FuncNameException(PatternException):
 class InvalidFuncDeclareException(PatternException):
     def __init__(self, arg="", line_num=None):
         super().__init__(arg, line_num)
-        self.message = f"{self.args}の関数定義が正しくありません。"
+        self.message = f"{self.arg}の関数定義が正しくありません。"
 
 
 class FuncArgNotFoundException(PatternException):
@@ -127,4 +127,4 @@ class LtsException(Exception):
 
 class DoesNotExistException(LtsException):
     def __str__(self):
-        return f"{self.args}はLTSに存在しません。"
+        return f"{self.arg}はLTSに存在しません。"

--- a/src/exception.py
+++ b/src/exception.py
@@ -63,7 +63,14 @@ class InvalidFormulaException(PatternException):
 class InvalidParenthesisException(PatternException):
     def __init__(self, arg="", line_num=None):
         super().__init__(arg, line_num)
-        self.message = f'"("に対応する")"が存在しません。:{self.args}'
+        self.message = f'"("に対応する")"が存在しません。:{self.arg}'
+
+
+class InvalidSquareBracketException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = '"["に対応する"]"が存在しません。'
+
 
 
 class InvalidIfBlockException(PatternException):

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -371,8 +371,41 @@ class Interpreter:
             )
             if res:
                 _, remain = res
-                val, remain = self.interpret_arithmetic_formula(remain, dry_run=dry_run)
-                self.name_val_map[name] = val
+                # 配列の代入は独立して実施
+                res = self.get_pattern_and_remain(
+                    self.square_bracket_start_pattern, remain
+                )
+                if res:
+                    _, remain = res
+                    array = []
+                    while True:
+                        if self.get_pattern_and_remain(
+                            self.square_bracket_end_pattern, remain
+                        ):
+                            break
+                        val, remain = self.interpret_arithmetic_formula(
+                            remain, dry_run=dry_run
+                        )
+                        if not res:
+                            break
+                        if not dry_run:
+                            array.append(val)
+                        res = self.get_pattern_and_remain(self.comma_pattern, remain)
+                        if res:
+                            _, remain = res
+                        else:
+                            break
+                    self.name_val_map[name] = array
+                    _, remain = self.get_pattern_and_remain(
+                        self.square_bracket_end_pattern,
+                        remain,
+                        exception.InvalidSquareBracketException,
+                    )
+                else:
+                    val, remain = self.interpret_arithmetic_formula(
+                        remain, dry_run=dry_run
+                    )
+                    self.name_val_map[name] = val
             else:
                 self.name_val_map[name] = None
             res = self.get_pattern_and_remain(

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -26,6 +26,8 @@ class Interpreter:
 
     PALENTHESIS_START = "^\\("
     PALENTHESIS_END = "^\\)"
+    SQUARE_BRACKET_START = "^\\["
+    SQUARE_BRACKET_END = "^\\]"
 
     # <論理値>::= true | false
     LOGICAL_VALUE = "true|false"
@@ -34,13 +36,13 @@ class Interpreter:
     # <数字> ::= 0 | <正数字>
     NUM = "0-9"
     # <英字> ::= a-z | A-Z
-    ALPHABET = "A-z"
+    ALPHABET = "a-zA-Z"
     # <数値> ::= <正数字><数値> | -<正数字><数値> | <数字>
     INT_VAL = "-?" + f"[{NUM}]+"
     REAL_VAL = f"{INT_VAL}(?:\\.[{NUM}]+)?"
     NUM_VAL = f"({REAL_VAL})"
     # <名前>
-    NAME = f"[{ALPHABET}]([{ALPHABET}]|[{NUM}])*"
+    NAME = f"[{ALPHABET}_]([{ALPHABET}_]|[{NUM}])*"
     # <被演算子>
     OPERAND = f"({NUM_VAL}|{NAME})"
 
@@ -192,6 +194,8 @@ class Interpreter:
 
         self.parenthesis_start_pattern = re.compile(self.PALENTHESIS_START)
         self.parenthesis_end_pattern = re.compile(self.PALENTHESIS_END)
+        self.square_bracket_start_pattern = re.compile(self.SQUARE_BRACKET_START)
+        self.square_bracket_end_pattern = re.compile(self.SQUARE_BRACKET_END)
         self.colon_pattern = re.compile(self.COLON)
         self.comma_pattern = re.compile(self.COMMA)
         self.assign_pattern = re.compile(self.ASSIGN)
@@ -303,6 +307,21 @@ class Interpreter:
                 raise exception.NameNotDefinedException(name)
             if stack is not None:
                 stack.append(name)
+            res = self.get_pattern_and_remain(self.square_bracket_start_pattern, remain)
+            if res:
+                _, remain = res
+                if type(self.name_val_map[name]) is not list:
+                    raise exception.InvalidArrayException(name)
+                index, remain = self.interpret_arithmetic_formula(remain)
+                _, remain = self.get_pattern_and_remain(
+                    self.square_bracket_end_pattern,
+                    remain,
+                    exception.InvalidSquareBracketException,
+                )
+                if not int(index) < len(self.name_val_map[name]):
+                    raise exception.InvalidArrayIndexException(name)
+                return self.name_val_map[name][int(index)], remain
+
             return self.name_val_map[name], remain
         num_val, remain = self.get_pattern_and_remain(
             self.num_val_pattern, line, exception.InvalidFormulaException
@@ -848,7 +867,7 @@ class Interpreter:
         ]
         for end in ends:
             self.lts.add_transition(end, "return", return_state)
-        return line_pointa        
+        return line_pointa
 
     def check_indent(self, line: str, indent: str):
         if indent == "":

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -232,6 +232,51 @@ def test_process_var_assigns():
     assert remain == ""
 
 
+def test_process_var_assigns_array():
+    interpreter = Interpreter()
+    actual_list, remain = interpreter.process_var_assigns("a←[1+2,3], b←[4,5*6], c←[]")
+    assert actual_list == ["a", "b", "c"]
+    assert interpreter.name_val_map["a"] == [3, 3]
+    assert interpreter.name_val_map["b"] == [4, 30]
+    assert interpreter.name_val_map["c"] == []
+    assert remain == ""
+
+
+def test_process_var_assigns_invalid_square_bracet():
+    interpreter = Interpreter()
+    with pytest.raises(exception.InvalidSquareBracketException) as e:
+        interpreter.process_var_assigns("a←[1+2,3")
+    assert str(e.value) == '"["に対応する"]"が存在しません。'
+
+
+def test_process_var_assigns_invalid_array():
+    interpreter = Interpreter()
+    interpreter.process_var_assigns("a←1+2")
+    with pytest.raises(exception.InvalidArrayException) as e:
+        interpreter.process_var_assigns("b←a[0]")
+    assert str(e.value) == "aは配列ではありません。"
+
+
+def test_process_var_assigns_array_access():
+    interpreter = Interpreter()
+    actual_list, remain = interpreter.process_var_assigns("a←[1+2,3], b←[4,5*6], c←[]")
+    actual_list, remain = interpreter.process_var_assigns("d←a[0]+b[1]")
+    assert actual_list == ["d"]
+    assert interpreter.name_val_map["a"] == [3, 3]
+    assert interpreter.name_val_map["b"] == [4, 30]
+    assert interpreter.name_val_map["c"] == []
+    assert interpreter.name_val_map["d"] == 33
+    assert remain == ""
+
+
+def test_process_var_assigns_array_invalid_access():
+    interpreter = Interpreter()
+    actual_list, remain = interpreter.process_var_assigns("a←[1+2,3], b←[4,5*6], c←[]")
+    with pytest.raises(exception.InvalidArrayIndexException) as e:
+        interpreter.process_var_assigns("d←a[0]+b[2]")
+    assert str(e.value) == "bの配列外にアクセスしています。"
+
+
 def test_interpret_var_declare():
     interpreter = Interpreter()
     remain = interpreter.interpret_var_declare("整数型：a←1, b, c←1+2+3")
@@ -250,6 +295,7 @@ def test_interpret_var_assign():
     remain = interpreter.interpret_var_assign("a←a+2+3")
     assert interpreter.name_val_map["a"] == 6
     assert remain == ""
+
 
 def test_process_var_assigns_and_use():
     interpreter = Interpreter()


### PR DESCRIPTION
# 対応内容
配列の宣言（代入）と配列へのアクセスに対して解釈器を追加しました。
配列型に限りませんが、型チェックは現時点では実装していません。


Close #13

# テスト項目
- [x] 配列の宣言ができること
- [x] 配列へのアクセスができること