### PR TITLE
配列の括弧と開始添字の修正

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -78,6 +78,12 @@ class InvalidSquareBracketException(PatternException):
         self.message = '"["に対応する"]"が存在しません。'
 
 
+class InvalidCurlyBracketException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = '"{"に対応する"}"が存在しません。'
+
+
 class InvalidArrayException(PatternException):
     def __init__(self, arg="", line_num=None):
         super().__init__(arg, line_num)

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -402,7 +402,7 @@ class Interpreter:
                     return None, remain
                 if int(index) > len(lts.name_val_map[name]) or int(index) < 1:
                     raise exception.InvalidArrayIndexException(name)
-                return lts.name_val_map[name][int(index)], remain
+                return lts.name_val_map[name][int(index) - 1], remain
 
             return lts.name_val_map[name], remain
         num_val, remain = self.get_pattern_and_remain(

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -63,6 +63,8 @@ class Interpreter:
     PALENTHESIS_END = "^\\)"
     SQUARE_BRACKET_START = "^\\["
     SQUARE_BRACKET_END = "^\\]"
+    CURLY_BRACKET_START = "^\\{"
+    CURLY_BRACKET_END = "^\\}"
 
     # <論理値>::= true | false
     LOGICAL_VALUE = "true|false"
@@ -204,7 +206,6 @@ class Interpreter:
     }
 
     def __init__(self):
-
         self.lts = PseudoCompiledLTS()
         self.func_lts_map = {}
         self.current_state = self.lts.get_init_state()
@@ -243,6 +244,9 @@ class Interpreter:
         self.parenthesis_end_pattern = re.compile(self.PALENTHESIS_END)
         self.square_bracket_start_pattern = re.compile(self.SQUARE_BRACKET_START)
         self.square_bracket_end_pattern = re.compile(self.SQUARE_BRACKET_END)
+        self.curly_bracket_start_pattern = re.compile(self.CURLY_BRACKET_START)
+        self.curly_bracket_end_pattern = re.compile(self.CURLY_BRACKET_END)
+
         self.colon_pattern = re.compile(self.COLON)
         self.comma_pattern = re.compile(self.COMMA)
         self.assign_pattern = re.compile(self.ASSIGN)
@@ -460,14 +464,14 @@ class Interpreter:
                 _, remain = res
                 # 配列の代入は独立して実施
                 res = self.get_pattern_and_remain(
-                    self.square_bracket_start_pattern, remain
+                    self.curly_bracket_start_pattern, remain
                 )
                 if res:
                     _, remain = res
                     array = []
                     while True:
                         if self.get_pattern_and_remain(
-                            self.square_bracket_end_pattern, remain
+                            self.curly_bracket_end_pattern, remain
                         ):
                             break
                         val, remain = self.interpret_arithmetic_formula(
@@ -484,9 +488,9 @@ class Interpreter:
                             break
                     lts.name_val_map[name] = array
                     _, remain = self.get_pattern_and_remain(
-                        self.square_bracket_end_pattern,
+                        self.curly_bracket_end_pattern,
                         remain,
-                        exception.InvalidSquareBracketException,
+                        exception.InvalidCurlyBracketException,
                     )
                 else:
                     val, remain = self.interpret_arithmetic_formula(

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -293,7 +293,7 @@ def test_interpret_var_assign():
     interpreter = Interpreter()
     remain = interpreter.interpret_var_declare("整数型：a←1")
     remain = interpreter.interpret_var_assign("a←a+2+3")
-    assert interpreter.name_val_map["a"] == 6
+    assert interpreter.lts.name_val_map["a"] == 6
     assert remain == ""
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -260,7 +260,7 @@ def test_process_var_assigns_invalid_array():
 def test_process_var_assigns_array_access():
     interpreter = Interpreter()
     actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
-    actual_list, remain = interpreter.process_var_assigns("d←a[0]+b[1]")
+    actual_list, remain = interpreter.process_var_assigns("d←a[1]+b[2]")
     assert actual_list == ["d"]
     assert interpreter.lts.name_val_map["a"] == [3, 3]
     assert interpreter.lts.name_val_map["b"] == [4, 30]
@@ -273,7 +273,7 @@ def test_process_var_assigns_array_invalid_access():
     interpreter = Interpreter()
     actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
     with pytest.raises(exception.InvalidArrayIndexException) as e:
-        interpreter.process_var_assigns("d←a[0]+b[2]")
+        interpreter.process_var_assigns("d←a[1]+b[3]")
     assert str(e.value) == "bの配列外にアクセスしています。"
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -234,7 +234,7 @@ def test_process_var_assigns():
 
 def test_process_var_assigns_array():
     interpreter = Interpreter()
-    actual_list, remain = interpreter.process_var_assigns("a←[1+2,3], b←[4,5*6], c←[]")
+    actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
     assert actual_list == ["a", "b", "c"]
     assert interpreter.lts.name_val_map["a"] == [3, 3]
     assert interpreter.lts.name_val_map["b"] == [4, 30]
@@ -244,9 +244,9 @@ def test_process_var_assigns_array():
 
 def test_process_var_assigns_invalid_square_bracet():
     interpreter = Interpreter()
-    with pytest.raises(exception.InvalidSquareBracketException) as e:
-        interpreter.process_var_assigns("a←[1+2,3")
-    assert str(e.value) == '"["に対応する"]"が存在しません。'
+    with pytest.raises(exception.InvalidCurlyBracketException) as e:
+        interpreter.process_var_assigns("a←{1+2,3")
+    assert str(e.value) == '"{"に対応する"}"が存在しません。'
 
 
 def test_process_var_assigns_invalid_array():
@@ -259,7 +259,7 @@ def test_process_var_assigns_invalid_array():
 
 def test_process_var_assigns_array_access():
     interpreter = Interpreter()
-    actual_list, remain = interpreter.process_var_assigns("a←[1+2,3], b←[4,5*6], c←[]")
+    actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
     actual_list, remain = interpreter.process_var_assigns("d←a[0]+b[1]")
     assert actual_list == ["d"]
     assert interpreter.lts.name_val_map["a"] == [3, 3]
@@ -271,7 +271,7 @@ def test_process_var_assigns_array_access():
 
 def test_process_var_assigns_array_invalid_access():
     interpreter = Interpreter()
-    actual_list, remain = interpreter.process_var_assigns("a←[1+2,3], b←[4,5*6], c←[]")
+    actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
     with pytest.raises(exception.InvalidArrayIndexException) as e:
         interpreter.process_var_assigns("d←a[0]+b[2]")
     assert str(e.value) == "bの配列外にアクセスしています。"


### PR DESCRIPTION
# 対応内容

配列定義時の括弧を擬似コードに合わせて`{}`から`[]`に修正しました。
また、開始の添字を`0`から`1`に修正しました。


Close #28 

# テスト項目
- [x] 配列を`{}`で定義した際に解釈できること
- [x] 配列のアクセス時の先頭が`1`になっていること