### PR TITLE
feat: 多次元配列と要素追加への対応

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -132,6 +132,12 @@ class InvalidIndentException(PatternException):
         self.message = "インデントに誤りがあります。"
 
 
+class InvalidVarAssignException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = "代入文が正しくありません。"
+
+
 class LtsException(Exception):
     def __init__(self, arg=""):
         self.arg = arg

--- a/src/exception.py
+++ b/src/exception.py
@@ -126,6 +126,12 @@ class InvalidForSentenceException(PatternException):
         self.message = "for文の繰り返しの定義が正しくありません。"
 
 
+class InvalidArrayAppendException(PatternException):
+    def __init__(self, arg="", line_num=None):
+        super().__init__(arg, line_num)
+        self.message = "配列への値の追加文が正しくありません。"
+
+
 class InvalidIndentException(PatternException):
     def __init__(self, arg="", line_num=None):
         super().__init__(arg, line_num)

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -665,13 +665,16 @@ class Interpreter:
         res = self.get_pattern_and_remain(
             self.square_bracket_start_pattern, remain, line_num=line_num
         )
-        if res:
+        while res:
             _, remain = res
             _, remain = self.interpret_arithmetic_formula(remain)
             _, remain = self.get_pattern_and_remain(
                 self.square_bracket_end_pattern,
                 remain,
                 exception.InvalidSquareBracketException,
+            )
+            res = self.get_pattern_and_remain(
+                self.square_bracket_start_pattern, remain, line_num=line_num
             )
         res = self.get_pattern_and_remain(
             self.assign_pattern, remain, line_num=line_num

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1310,7 +1310,6 @@ class Interpreter:
     def fire_transition(self, state: str, lts: PseudoCompiledLTS):
         # 基本的に最初の遷移ラベルは使うのでここで取得してしまう
         label = lts.get_transition_label(state)
-        print(state, "(", lts.get_state_type(state), "),", label, lts.name_val_map)
         val = None
         if lts.get_state_type(state) in [StateType.IF, StateType.WHILE]:
             return self.get_transition_on_condition_state(state, lts)

--- a/src/lts/lts.py
+++ b/src/lts/lts.py
@@ -57,6 +57,16 @@ class LabeledTransitionSystem:
             raise exception.DoesNotExistException(target)
         return self.backwards[target]
 
+    def get_transition_label(self, state:str, index=0):
+        if state not in self.transitions:
+            raise exception.DoesNotExistException(state)
+        # 存在しないインデックスへのアクセスはNoneを返却する
+        if not index < len(self.transitions[state]):
+            return None
+        # WARNING: keysの順序は本来不定なのでif文のように順序付きを扱うのは不適？
+        key = list(self.transitions[state].keys())[index]
+        return key
+
     def __str__(self):
         lts_str = ""
         for state in self.transitions:

--- a/src/lts/lts.py
+++ b/src/lts/lts.py
@@ -52,7 +52,7 @@ class LabeledTransitionSystem:
             raise exception.DoesNotExistException(f"{source}から{label}による遷移")
         return self.transitions[source][label]
 
-    def get_backwards(self, target):
+    def get_backwards(self, target:str):
         if target not in self.backwards:
             raise exception.DoesNotExistException(target)
         return self.backwards[target]

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -306,7 +306,20 @@ def test_process_var_assigns_array_access():
     assert interpreter.lts.name_val_map["b"] == [4, 30]
     assert interpreter.lts.name_val_map["c"] == []
     assert interpreter.lts.name_val_map["d"] == 33
+    actual_list, remain = interpreter.process_var_assigns("b[1]←a[1]+b[2]")
+    assert interpreter.lts.name_val_map["b"] == [33, 30]
+
     assert remain == ""
+
+
+def test_process_var_assigns_n_array():
+    interpreter = Interpreter()
+    interpreter.process_var_assigns("a←{{1,2},{3}}, b←{{{4,5},{6,7}},{{8},{9}}}, c←{}")
+    assert interpreter.lts.name_val_map["a"] == [[1, 2], [3]]
+    assert interpreter.lts.name_val_map["b"] == [[[4, 5], [6, 7]], [[8], [9]]]
+    assert interpreter.lts.name_val_map["c"] == []
+    interpreter.process_var_assigns("a[1][2]←a[1][1]+b[1][2][2]")
+    assert interpreter.lts.name_val_map["a"] == [[1, 8], [3]]
 
 
 def test_process_var_assigns_array_invalid_access():
@@ -327,6 +340,14 @@ def test_interpret_var_declare():
     assert interpreter.lts.name_type_map["b"] == "整数型"
     assert interpreter.lts.name_type_map["c"] == "整数型"
     remain == ""
+
+
+def test_interpret_var_declare_array():
+    interpreter = Interpreter()
+    interpreter.interpret_var_declare("整数型の二次元配列: a ← {{0,1,2},{3,4,5},{6,7,8}}")
+    interpreter.interpret_var_declare("整数型配列の配列： b ← {{8,7,6},{5,4,3},{2,1,0}}")
+    assert interpreter.lts.name_val_map["a"] == [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+    assert interpreter.lts.name_val_map["b"] == [[8, 7, 6], [5, 4, 3], [2, 1, 0]]
 
 
 def test_interpret_var_assign():

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -322,6 +322,17 @@ def test_process_var_assigns_n_array():
     assert interpreter.lts.name_val_map["a"] == [[1, 8], [3]]
 
 
+def test_interpret_var_declare_n_array():
+    interpreter = Interpreter()
+    interpreter.interpret_var_declare("整数型の二次元配列: a←{{1,2},{3}}")
+    interpreter.interpret_var_declare("整数型の三次元配列: b←{{{4,5},{6,7}},{{8},{9}}}")
+    interpreter.interpret_var_declare("整数型配列: c←{}")
+    assert interpreter.lts.name_val_map["a"] == [[1, 2], [3]]
+    assert interpreter.lts.name_val_map["b"] == [[[4, 5], [6, 7]], [[8], [9]]]
+    assert interpreter.lts.name_val_map["c"] == []
+    interpreter.interpret_var_assign("a[1][2]←a[1][1]+b[1][2][2]")
+    assert interpreter.lts.name_val_map["a"] == [[1, 8], [3]]
+
 def test_process_var_assigns_array_invalid_access():
     interpreter = Interpreter()
     actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
@@ -344,8 +355,12 @@ def test_interpret_var_declare():
 
 def test_interpret_var_declare_array():
     interpreter = Interpreter()
-    interpreter.interpret_var_declare("整数型の二次元配列: a ← {{0,1,2},{3,4,5},{6,7,8}}")
-    interpreter.interpret_var_declare("整数型配列の配列： b ← {{8,7,6},{5,4,3},{2,1,0}}")
+    interpreter.interpret_var_declare(
+        "整数型の二次元配列: a ← {{0,1,2},{3,4,5},{6,7,8}}"
+    )
+    interpreter.interpret_var_declare(
+        "整数型配列の配列： b ← {{8,7,6},{5,4,3},{2,1,0}}"
+    )
     assert interpreter.lts.name_val_map["a"] == [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
     assert interpreter.lts.name_val_map["b"] == [[8, 7, 6], [5, 4, 3], [2, 1, 0]]
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1220,3 +1220,22 @@ def test_interpret_sample1():
     interpreter.interpret_main_process(lines)
     interpreter.execute_lts()
     assert interpreter.lts.name_val_map["fee_value"] == 300
+
+
+def test_interpret_sample2():
+    lines = [
+        "整数型の配列: array ← {1, 2, 3, 4, 5}",
+        "整数型: right, left",
+        "整数型: tmp",
+        "for (left を 1 から (arrayの要素数 ÷ 2 の商) まで 1 ずつ増やす)",
+        "    right ← array の要素数 － left ＋ 1",
+        "    tmp ← array[right]",
+        "    array[right] ← array[left]",
+        "    array[left] ← tmp",
+        "endfor",
+    ]
+    interpreter = Interpreter()
+    interpreter.interpret_main_process(lines)
+    print(interpreter.lts)
+    interpreter.execute_lts()
+    assert interpreter.lts.name_val_map["array"] == [5, 4, 3, 2, 1]

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -333,6 +333,7 @@ def test_interpret_var_declare_n_array():
     interpreter.interpret_var_assign("a[1][2]←a[1][1]+b[1][2][2]")
     assert interpreter.lts.name_val_map["a"] == [[1, 8], [3]]
 
+
 def test_process_var_assigns_array_invalid_access():
     interpreter = Interpreter()
     actual_list, remain = interpreter.process_var_assigns("a←{1+2,3}, b←{4,5*6}, c←{}")
@@ -371,6 +372,35 @@ def test_interpret_var_assign():
     remain = interpreter.interpret_var_assign("a←a+2+3")
     assert interpreter.lts.name_val_map["a"] == 6
     assert remain == ""
+
+
+def test_interpret_var_assign_array_append():
+    interpreter = Interpreter()
+    # TODO 配列への値の追加のテスト
+    interpreter.interpret_var_declare("整数型の配列：a← {}")
+    interpreter.interpret_var_declare("整数型配列の配列：b ← {{},{}}")
+    interpreter.interpret_var_assign("aの末尾 に 1を追加する")
+    interpreter.interpret_var_assign("b[1]の末尾 に {1,2,3}を追加する")
+    print(interpreter.lts.name_val_map)
+    assert interpreter.lts.name_val_map["a"] == [1]
+    assert interpreter.lts.name_val_map["b"] == [[[1, 2, 3]], []]
+
+
+def test_interpret_var_assign_invalid_array_append():
+    interpreter = Interpreter()
+    # TODO 配列への値の追加のテスト
+    interpreter.interpret_var_declare("整数型の配列：a← {}")
+    with pytest.raises(exception.InvalidArrayAppendException) as e:
+        interpreter.interpret_var_assign("aの末尾 に 1を追加")
+    assert str(e.value) == "配列への値の追加文が正しくありません。"
+
+def test_interpret_var_assign_append_invalid_var():
+    interpreter = Interpreter()
+    # TODO 配列への値の追加のテスト
+    interpreter.interpret_var_declare("整数型：a← 3")
+    with pytest.raises(exception.InvalidArrayException) as e:
+        interpreter.interpret_var_assign("aの末尾 に 1を追加する")
+    assert str(e.value) == "aは配列ではありません。"
 
 
 def test_process_var_assigns_and_use():


### PR DESCRIPTION
# 対応内容

多次元配列を定義する型宣言の解釈、および多次元配列の定義やアクセス機構を追加しました。
加えて配列への要素追加の機構も併せて追加しました。

Close #32 

# テスト項目

- [x] 多次元配列の型宣言を`配列の配列`や`二次元配列`という語句で定義できること
- [x] 多次元配列の値を定義できること（配列の入れ子構造を解釈できること）
- [x] 多次元配列にアクセスできること（`[]`による指定を連ねることができること）
- [x] 配列名を指定して`…の末尾に〜を追加する`という語句を解釈し、対象配列に要素を追加できること
