### PR TITLE
feat: 配列の長さを取得する語句および演算子語句の追加

### DIFF
--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -52,7 +52,7 @@ class Interpreter:
     COMPARE_START_OPERATOR_JP = "が"
     # <日本語比較演算子>
     COMPARE_OPERATOR_JP = (
-        "(と|に)等し(い|くない)|以上|以下|より(大きい|小さい)|未満|未定義(でない)?|でない|である"
+        "(と|に)等し(い|くない)|以上|以下|より(大きい|小さい)|未満|未定義(でない)?|でない|である|で割り切れる"
     )
     ARRAY_APPEND_START = "の末尾\\s*に\\s*"
     ARRAY_APPEND_END = "を追加する"
@@ -171,6 +171,7 @@ class Interpreter:
         "未満": lambda val1, val2: val1 < val2,
         "でない": lambda val1, val2: val1 is not val2,
         "である": lambda val1, val2: val1 is val2,
+        "で割り切れる": lambda val1, val2: (val1 % val2) == 0
     }
     JP_SINGLE_OPERATOR_FUNC_MAP = {
         "未定義": lambda val: val is None,

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -52,7 +52,7 @@ class Interpreter:
     COMPARE_START_OPERATOR_JP = "が"
     # <日本語比較演算子>
     COMPARE_OPERATOR_JP = (
-        "(と|に)等し(い|くない)|以上|以下|より(大きい|小さい)|未満|未定義(でない)?"
+        "(と|に)等し(い|くない)|以上|以下|より(大きい|小さい)|未満|未定義(でない)?|でない|である"
     )
     ARRAY_APPEND_START = "の末尾\\s*に\\s*"
     ARRAY_APPEND_END = "を追加する"
@@ -136,7 +136,8 @@ class Interpreter:
     FOR_OP3 = "まで"
     FOR_OP4 = "繰り返す"
     FOR_OP4_2 = "ずつ増やす"
-    LENGTH = "の要素数"
+    LENGTH = "(の要素数)|(の行数)|(の列数)"
+    ROW_LENGTH = "の列数"
     QUOTIENT = "の商"
     REMAINDER = "の余り"
     EXTRA_OPERATOR = f"{QUOTIENT}|{REMAINDER}"
@@ -168,6 +169,8 @@ class Interpreter:
         "より大きい": lambda val1, val2: val1 > val2,
         "より小さい": lambda val1, val2: val1 < val2,
         "未満": lambda val1, val2: val1 < val2,
+        "でない": lambda val1, val2: val1 is not val2,
+        "である": lambda val1, val2: val1 is val2,
     }
     JP_SINGLE_OPERATOR_FUNC_MAP = {
         "未定義": lambda val: val is None,
@@ -487,11 +490,13 @@ class Interpreter:
                 return return_target, remain
             res = self.get_pattern_and_remain(self.length_pattern, remain)
             if res:
-                _, remain = res
+                length_name, remain = res
                 if type(lts.name_val_map[name]) is not list:
                     raise exception.InvalidArrayException(name)
                 if dry_run:
                     return None, remain
+                if length_name == self.ROW_LENGTH:
+                    return len(lts.name_val_map[name][0]), remain
                 return len(lts.name_val_map[name]), remain
 
             return lts.name_val_map[name], remain

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -244,6 +244,16 @@ def test_interpret_formula_jp_com_op():
     actual_val, _ = interpreter.interpret_arithmetic_formula("1 が 未定義")
     assert not actual_val
     actual_val, _ = interpreter.interpret_arithmetic_formula("1 が 未定義でない")
+    assert actual_val
+    actual_val, _ = interpreter.interpret_arithmetic_formula("1 が 1 でない")
+    assert not actual_val
+    actual_val, _ = interpreter.interpret_arithmetic_formula("1 が 1 である")
+    assert actual_val
+    actual_val, _ = interpreter.interpret_arithmetic_formula("4 が 2 で割り切れる")
+    assert actual_val
+    actual_val, _ = interpreter.interpret_arithmetic_formula("4 が 3 で割り切れる")
+    assert not actual_val
+
 
 
 def test_interpret_formula_jp_extra_op():
@@ -256,10 +266,13 @@ def test_interpret_formula_jp_extra_op():
 
 def test_interpret_formula_jp_length_op():
     interpreter = Interpreter()
-    interpreter.interpret_var_declare("整数型の配列: a ← {1, 2, 3}")
+    interpreter.interpret_var_declare("整数型の配列: a ← {{1, 2},{3, 4},{5, 6}}")
     actual_val, _ = interpreter.interpret_arithmetic_formula("aの要素数")
     assert actual_val == 3
-
+    actual_val, _ = interpreter.interpret_arithmetic_formula("aの行数")
+    assert actual_val == 3
+    actual_val, _ = interpreter.interpret_arithmetic_formula("aの列数")
+    assert actual_val == 2
 
 def test_process_var_assigns():
     interpreter = Interpreter()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -394,6 +394,7 @@ def test_interpret_var_assign_invalid_array_append():
         interpreter.interpret_var_assign("aの末尾 に 1を追加")
     assert str(e.value) == "配列への値の追加文が正しくありません。"
 
+
 def test_interpret_var_assign_append_invalid_var():
     interpreter = Interpreter()
     # TODO 配列への値の追加のテスト
@@ -1284,3 +1285,41 @@ def test_interpret_sample2():
     print(interpreter.lts)
     interpreter.execute_lts()
     assert interpreter.lts.name_val_map["array"] == [5, 4, 3, 2, 1]
+
+
+def test_interpret_sample3():
+    lines = [
+        "○整数型配列の配列: transformSparseMatrix(整数型の二次元配列: matrix)",
+        "    整数型: i, j",
+        "    整数型配列の配列: sparseMatrix",
+        "    sparseMatrix ← {{}, {}, {}}",
+        "    for (i を 1 から matrixの行数 まで 1 ずつ増やす)",
+        "        for (j を 1 から matrixの列数 まで 1 ずつ増やす)",
+        "            if (matrix[i][j] が 0 でない)",
+        "                sparseMatrix[1]の末尾 に iの値 を追加する",
+        "                sparseMatrix[2]の末尾 に jの値 を追加する",
+        "                sparseMatrix[3]の末尾 に matrix[i][j]の値 を追加する",
+        "            endif",
+        "        endfor",
+        "    endfor",
+        "    return sparseMatrix",
+    ]
+    interpreter = Interpreter()
+    interpreter.interpret_main_process(lines)
+    print(interpreter.func_lts_map["transformSparseMatrix"])
+    test_list = [
+        [3, 0, 0, 0, 0],
+        [0, 2, 2, 0, 0],
+        [0, 0, 0, 1, 3],
+        [0, 0, 0, 2, 0],
+        [0, 0, 0, 0, 1],
+    ]
+    actual_val = interpreter.execute_lts(
+        interpreter.func_lts_map["transformSparseMatrix"], vars=[test_list]
+    )
+    print(interpreter.func_lts_map["transformSparseMatrix"].name_val_map)
+    assert actual_val == [
+        [1, 2, 2, 3, 3, 4, 5],
+        [1, 2, 3, 4, 5, 4, 5],
+        [3, 2, 2, 1, 3, 2, 1],
+    ]


### PR DESCRIPTION
# 対応内容

特殊な配列（行列）で用いられる語句である`行数`および`列数`を解釈可能にしました。
また、`である`や`でない`をpythonの`is`, `is not`として解釈可能にしました。

Close #39 

# テスト項目

- [x] `である`が解釈・実行できること
- [x] `でない`が解釈・実行できること
- [x] `行数`が解釈・実行できること
- [x] `列数`が解釈・実行できること
- [x] `割り切れる`が解釈・実行できること